### PR TITLE
Enable OverloadedStrings in generated modules

### DIFF
--- a/src/Pinch/Generate.hs
+++ b/src/Pinch/Generate.hs
@@ -88,7 +88,7 @@ gProgram s inp (Program headers defs) = do
   let tyMap = Map.unions tyMaps
   let (typeDecls, clientDecls, serverDecls) = unzip3 $ runReader (traverse gDefinition defs) $ Context tyMap s
   let mkMod suffix = H.Module (H.ModuleName $ modBaseName <> suffix)
-        [ H.PragmaLanguage "TypeFamilies, DeriveGeneric, TypeApplications"
+        [ H.PragmaLanguage "TypeFamilies, DeriveGeneric, TypeApplications", "OverloadedStrings"
         , H.PragmaOptsGhc "-fno-warn-unused-imports -fno-warn-name-shadowing -fno-warn-unused-matches" ]
   pure $
     [ -- types


### PR DESCRIPTION
I found that the generated code for Client and Server requires OverloadedStrings to be enabled: 

```
...
submitBatches :: ((Data.Vector.Vector Batch)) -> (Pinch.Client.ThriftCall SubmitBatches_Result)
submitBatches batches = Pinch.Client.TCall ("submitBatches") (SubmitBatches_Args (batches))
```

See the `"submitBatches"` bit, it seems to be required to be a Text instead of plain String. 