### PR TITLE
Support for Thrift constants

### DIFF
--- a/src/Pinch/Generate/Pretty.hs
+++ b/src/Pinch/Generate/Pretty.hs
@@ -104,6 +104,7 @@ data Alt
 
 data Lit
   = LInt Integer
+  | LFloat Double
   | LString T.Text
   deriving (Show)
 
@@ -204,6 +205,7 @@ instance Pretty Stm where
 instance Pretty Lit where
   pretty l = case l of
     LInt i -> pretty i
+    LFloat f -> pretty f
     LString t -> "\"" <> pretty t <> "\""
 
 cList = concatWith (surround (comma <> space))


### PR DESCRIPTION
In order to switch the opentracing-jaeger and opentracing-zipkin-v1 packages over to pinch (the original thrift package has been deprecated and support discontinued) I need to generate code for https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift which unfortunately uses Thrift constants. 

This PR adds support the various types of constants. To keep code generation as simple as possible I render Map and List constants as Haskell lists and defer construction of Vector and HashMap to the OverloadedLists extensions.