### PR TITLE
feat: Use vsep to make records legible

### DIFF
--- a/src/Pinch/Generate.hs
+++ b/src/Pinch/Generate.hs
@@ -475,11 +475,11 @@ gFieldType f = do
 
 gFunction :: Function SourcePos -> GenerateM (H.Name, H.Type, H.Exp, [H.Decl], [H.Decl])
 gFunction f = do
-  argTys <- traverse (fmap snd . gFieldType) (functionParameters f)
+  argTys <- traverse (fmap snd . gFieldType) (A.functionParameters f)
   retType <- maybe (pure tyUnit) gTypeReference (functionReturnType f)
 
 
-  argDataTy <- structDatatype argDataTyNm (functionParameters f)
+  argDataTy <- structDatatype argDataTyNm (A.functionParameters f)
   let catchers = map
         (\e -> H.EApp "Control.Exception.Handler"
           [ H.EInfix "Prelude.." "Prelude.pure" (H.EVar $ dtNm <> "_" <> capitalize (fieldName e))
@@ -519,10 +519,10 @@ gFunction f = do
   let clientFunTy = H.TyLam argTys (H.TyApp (H.TyCon "Pinch.Client.ThriftCall") [resultDataTy])
   let callSig = H.TypeSigDecl nm $ clientFunTy
   let call = H.FunBind
-        [ H.Match nm ( map (H.PVar . fieldName) $ functionParameters f)
+        [ H.Match nm ( map (H.PVar . fieldName) $ A.functionParameters f)
           ( H.EApp (if functionOneWay f then "Pinch.Client.TOneway" else "Pinch.Client.TCall")
             [ H.ELit $ H.LString $ functionName f
-            , H.EApp (H.EVar argDataTyNm) $ map (H.EVar . fieldName) (functionParameters f)
+            , H.EApp (H.EVar argDataTyNm) $ map (H.EVar . fieldName) (A.functionParameters f)
             ]
           )
         ]
@@ -542,7 +542,7 @@ gFunction f = do
   where
     nm = decapitalize $ functionName f
     dtNm = capitalize (functionName f) <> "_Result"
-    argVars = take (length $ functionParameters f) $ map T.singleton ['a'..]
+    argVars = take (length $ A.functionParameters f) $ map T.singleton ['a'..]
     argDataTyNm = capitalize $ functionName f <> "_Args"
     exceptions = concat $ maybeToList $ functionExceptions f
 

--- a/src/Pinch/Generate/Pretty.hs
+++ b/src/Pinch/Generate/Pretty.hs
@@ -154,8 +154,15 @@ instance Pretty Deriving where
 
 instance Pretty ConDecl where
   pretty (ConDecl n args) = hsep $ [ pretty n ] ++ map pretty args
-  pretty (RecConDecl n args) = hsep $ [ pretty n, "{", fields, "}" ]
-    where fields = cList $ map (\(f, v) -> pretty f <+> "::" <+> pretty v) args
+  pretty (RecConDecl n fields) = pretty n
+    <> case fields of
+      [] -> "{}"
+      ((f, t) : xs) -> line
+        <> "{" <+> pretty f <+> "::" <+> pretty t
+          <> line
+          <> vsep (map (\(f', v) -> "," <+> pretty f' <+> "::" <+> pretty v) xs)
+          <> line
+          <> "}"
 
 instance Pretty InstHead where
   pretty (InstHead cs n ty) = "instance" <> context <+> pretty n <+> pretty ty <+> "where"


### PR DESCRIPTION
## Before

```haskell
data TLocalPrlDetails
  = TLocalPrlDetails { tLocalPrlDetails_startRange :: Data.Int.Int32, tLocalPrlDetails_endRange
 :: Data.Int.Int32, tLocalPrlDetails_deadBand :: Data.Int.Int32, tLocalPrlDetails_numberSlices :
: Data.Int.Int32, tLocalPrlDetails_mboxGroup :: Data.Int.Int32, tLocalPrlDetails_reshufflingTime
 :: Data.Int.Int32, tLocalPrlDetails_localPrlActive :: Data.Int.Int32 }
```

## After

```haskell
data TLocalPrlDetails
 = TLocalPrlDetails
  { tLocalPrlDetails_startRange :: Data.Int.Int32
  , tLocalPrlDetails_endRange :: Data.Int.Int32
  , tLocalPrlDetails_deadBand :: Data.Int.Int32
  , tLocalPrlDetails_numberSlices :: Data.Int.Int32
  , tLocalPrlDetails_mboxGroup :: Data.Int.Int32
  , tLocalPrlDetails_reshufflingTime :: Data.Int.Int32
  , tLocalPrlDetails_localPrlActive :: Data.Int.Int32
  }
```

This includes the changes from https://github.com/phile314/pinch-gen/pull/13 (so please merge that first).